### PR TITLE
Fix #21

### DIFF
--- a/R/parse.R
+++ b/R/parse.R
@@ -17,7 +17,15 @@ ada_url_parse <- function(url, decode = TRUE) {
 
 .decoder <- function(df) {
     for (i in seq_len(ncol(df))) {
-        df[[i]] <- utils::URLdecode(df[[i]])
+        df[[i]] <- .URLdecode(df[[i]])
     }
     df
+}
+
+## NA-aware utils::URLdecode, hopefully without great performance impact
+.URLdecode <- function(URL) {
+    non_na_index <- which(!is.na(URL))
+    URL[non_na_index] <- utils::URLdecode(URL[non_na_index])
+    URL[!non_na_index] <- NA_character_
+    return(URL)
 }

--- a/tests/testthat/test-urldecode.R
+++ b/tests/testthat/test-urldecode.R
@@ -1,0 +1,14 @@
+test_that(".URLdecode #21", {
+    expect_equal(.URLdecode("?q=%E3%83%89%E3%82%A4%E3%83%84"), "?q=\u30c9\u30a4\u30c4")
+    expect_equal(.URLdecode(c("?q=%E3%83%89%E3%82%A4%E3%83%84", NA)), c("?q=\u30c9\u30a4\u30c4", NA_character_))
+    ## corners
+    expect_equal(.URLdecode(""), "")
+    expect_equal(.URLdecode(NA_character_), NA_character_)
+    expect_equal(.URLdecode(NA), NA_character_)
+    expect_equal(.URLdecode(NULL), character(0))
+})
+
+test_that("Integration #21", {
+    res <- adaR::ada_url_parse(c("https://www.google.co.jp/search?q=\u30c9\u30a4\u30c4", NA, "https://www.google.co.jp/search?q=\u30c9\u30a4\u30c4"))
+    expect_equal(res$search, c("?q=\u30c9\u30a4\u30c4", NA_character_, "?q=\u30c9\u30a4\u30c4"))
+})


### PR DESCRIPTION
```r
benchmark
urls <- rep("https://www.google.co.jp/search?q=\u30c9\u30a4\u30c4", 10000)
urls[sample(1:10000, 100)] <- NA
bench::mark(adaR::ada_url_parse(urls))
```

it increases from 997ms (79a23d9ffeb17eab51a1c64b9437c65ca45fd960) to 1040ms. But negligible.